### PR TITLE
V1.2.6

### DIFF
--- a/Projects/S2E_App/src/common.h
+++ b/Projects/S2E_App/src/common.h
@@ -9,7 +9,7 @@
 /* Application Firmware Version */
 #define MAJOR_VER               1
 #define MINOR_VER               2
-#define MAINTENANCE_VER         7
+#define MAINTENANCE_VER         6
 
 //#define STR_VERSION_STATUS      "Develop" // or "Stable"
 #define STR_VERSION_STATUS      "Stable"

--- a/Projects/S2E_App/src/main.c
+++ b/Projects/S2E_App/src/main.c
@@ -8,7 +8,7 @@
   ******************************************************************************
   * @attention
   * @par Revision history
-  *    <2019/10/08> v1.2.6 Bugfix and Improvements by irina
+  *    <2019/10/11> v1.2.6 Bugfix and Improvements by irina
   *						  Modified Packing time
   *    <2018/09/19> v1.2.5 Bugfix and Improvements by Becky	
   *    <2018/06/22> v1.2.4 Bugfix by Eric Jung

--- a/Projects/S2E_Boot/src/main.c
+++ b/Projects/S2E_Boot/src/main.c
@@ -8,8 +8,7 @@
   ******************************************************************************
   * @attention
   * @par Revision history
-  *    <2019/10/11> v1.2.7 Bugfix and Improvements by irina
-  *    <2019/10/08> v1.2.6 Bugfix and Improvements by irina
+  *    <2019/10/11> v1.2.6 Bugfix and Improvements by irina
   *						  Modified Packing time
   *    <2019/09/19> v1.2.5 Bugfix and Improvements by Becky
   *    <2018/06/22> v1.2.4 Bugfix by Eric Jung

--- a/README.md
+++ b/README.md
@@ -78,14 +78,15 @@ These are Firmware projects (source code) based on Keil IDE for ARM (version 5)
  
  
 ## Update History
-v1.2.7 Stable
-- Improvements:
-  - while dhcp operate, device search as possibility.
-  - while DHCP operate, Device mode change(AT mode <-> GW mode) as possibility.
 
 v1.2.6 Stable
+- Bug fixes:
+  - If serial data packing 'time' option  is less than 500ms, the first serial data(+++) ignored in GW mode.
+
 - Improvements:
-  - Modified Packing time
+  - While IP address allocation using DHCP,
+    the device can be searchable using the Configuration tool and it can change the mode(AT mode <-> GW mode).
+ 
 
 v1.2.5 Stable
 - Bug fixes:


### PR DESCRIPTION
Bug Fix:
  - If serial data packing 'time' option  is less than 500ms, the first serial data(+++) ignored in GW mode.

- Improvements:
  - While IP address allocation using DHCP,
    the device can be made searchable using the Configuration tool and it can change the mode(AT mode <-> GW mode).